### PR TITLE
让脚本运行得更及时

### DIFF
--- a/Treenigence.user.js
+++ b/Treenigence.user.js
@@ -14,8 +14,14 @@
 (function() {
     'use strict';
     debugger;
-
-    window.setTimeout(knowledgeAnalysis, 5000);
+    beautifyknowledgeAnalysis();
+    //window.setTimeout(knowledgeAnalysis, 5000);
+    if(location.href.includes("knowledgeAnalysis"))
+       tryUntil(function() {return document.querySelector(".listTi")}, 50, 10000).then(knowledgeAnalysis);
+    tryUntil(function() {return document.querySelector(".Tips .ZHIHUISHU_QZMD")}, 50, 10000).then(function() {
+        // 自动关闭提示
+        document.querySelector('.Tips .ZHIHUISHU_QZMD').click();
+    });
 })();
 
 function injectCSS(text)
@@ -25,7 +31,7 @@ function injectCSS(text)
     document.documentElement.appendChild(styleEle);
 }
 
-function knowledgeAnalysis()
+function beautifyknowledgeAnalysis()
 {
     injectCSS(`
         .wrongLIST,
@@ -53,14 +59,15 @@ function knowledgeAnalysis()
             height: auto !important;
         }
     `);
-
+}
     // htmlToImage.toPng(document.querySelector(".listTi")).then(function (dataUrl) {
     //     var link = document.createElement('a');
     //     link.download = 'my-image-name.png';
     //     link.href = dataUrl;
     //     link.click();
     // });
-
+function knowledgeAnalysis()
+{
     var listTi = document.querySelectorAll('.listTi');
     for (var i = 0; i < listTi.length; i++)
     {
@@ -76,6 +83,32 @@ function knowledgeAnalysis()
         }
         listTi[i].appendChild(button);
     }
-    // 自动关闭提示
-    document.querySelector('.Tips .ZHIHUISHU_QZMD').click();
+
+
+}
+
+function tryUntil(condition, duration, maxTime)
+{
+    var tryCount = Math.ceil(maxTime / duration) + 1;
+    return new Promise(function(ok, error) {
+        function trier()
+        {
+            try
+            {
+                if(condition())
+                {
+                    ok();
+                    return;
+                }
+            }
+            catch(e)
+            {
+                console.warning("Treenigence: 运行条件判断时出现错误。", e);
+                error(e);
+            }
+            if(tryCount--) setTimeout(trier, duration);
+            else           error("Timeout");
+        }
+        trier();
+    });
 }


### PR DESCRIPTION
使脚本各部分能尽早开始运转，减少页面刷新延迟。

用 setTimeout 推迟脚本运行可行，但是会大幅推迟部分内容起作用的时间。同时，网页内容在较差的网络以及电脑中不能快速加载也会让 setTimeout 无法推迟到合理的位置。

这个 Pull Request 引入函数 ` tryUntil `，返回 Promise，可检查某一条件，当条件满足（返回 truty 值）时，Promise resolve。从而利于等待某部分加载这一问题。并且，已将这一函数应用于添加“保存”按钮以及关闭Tip。

